### PR TITLE
Change sendMessage method

### DIFF
--- a/Lib/Inc/uart_com.h
+++ b/Lib/Inc/uart_com.h
@@ -11,7 +11,7 @@
 #ifndef UART_COM_H_
 #define UART_COM_H_
 
-#include <string.h>
+#include <string>
 #include "usart.h"
 
 #define UART_TIMEOUT 100
@@ -29,9 +29,7 @@ public:
              GPIO_TypeDef *uart_de_port,
              uint16_t uart_de_pin);
 
-    // I'm using C style strings because the UART HAL uses (uint8_t*) as
-    // parameter
-    void sendMessage(const char *msg);
+    void sendMessage(const std::string &msg);
 };
 
 #endif /* UART_COM_H_ */

--- a/Lib/Src/uart_com.cpp
+++ b/Lib/Src/uart_com.cpp
@@ -32,9 +32,9 @@ CUartCom::CUartCom(UART_HandleTypeDef &huart,
  * @brief sends message via UART
  * @param string message
  */
-void CUartCom::sendMessage(const char *msg)
+void CUartCom::sendMessage(const std::string &msg)
 {
-    uint16_t msg_len = strlen(msg);
+    uint16_t msg_len = msg.length();
 
     // Enable UART_DE Pin
     if (m_uart_de_port != NULL)
@@ -42,8 +42,30 @@ void CUartCom::sendMessage(const char *msg)
         HAL_GPIO_WritePin(m_uart_de_port, m_uart_de_pin, GPIO_PIN_SET);
     }
 
+    // Convert string to C style
+    const char *c_msg = msg.c_str();
+
+    // Check it is a valid string and send error message if not
+    if (!(*c_msg) || c_msg == NULL)
+    {
+        const uint8_t error_msg_len = 28;
+        const char *error_msg = "Invalid string from c_str()\n";
+        HAL_UART_Transmit(&m_huart,
+                          (uint8_t *)error_msg,
+                          error_msg_len,
+                          UART_TIMEOUT);
+
+        // Disable UART_DE Pin
+        if (m_uart_de_port != NULL)
+        {
+            HAL_GPIO_WritePin(m_uart_de_port, m_uart_de_pin, GPIO_PIN_RESET);
+        }
+
+        return;
+    }
+
     // Send message
-    HAL_UART_Transmit(&m_huart, (uint8_t *)msg, msg_len, UART_TIMEOUT);
+    HAL_UART_Transmit(&m_huart, (uint8_t *)c_msg, msg_len, UART_TIMEOUT);
 
     // Disable UART_DE Pin
     if (m_uart_de_port != NULL)


### PR DESCRIPTION
Now the sendMessage method accepts a C++ string as input instead of a const char*. 
This makes it easier to catch errors when converting strings to C-style. 