### PR TITLE
refactor: rename isCommandAvailble() and getCommand() 

### DIFF
--- a/Lib/Inc/CUartCom.h
+++ b/Lib/Inc/CUartCom.h
@@ -36,8 +36,8 @@ public:
 
     void startRx();
     bool send(const etl::string<MAX_STRING_SIZE> msg);
-    bool isCommandAvailable();
-    etl::string<MAX_STRING_SIZE> getCommand();
+    bool isDataAvailable();
+    etl::string<MAX_STRING_SIZE> getData();
     void uartRxHandler(UART_HandleTypeDef *p_huart);
     void uartTxHandler(UART_HandleTypeDef *p_huart);
 

--- a/Lib/Inc/IComChannel.h
+++ b/Lib/Inc/IComChannel.h
@@ -27,8 +27,8 @@ public:
         return m_name;
     };
 
-    virtual bool isCommandAvailable() = 0;
-    virtual etl::string<MAX_STRING_SIZE> getCommand() = 0;
+    virtual bool isDataAvailable() = 0;
+    virtual etl::string<MAX_STRING_SIZE> getData() = 0;
     virtual bool send(etl::string<MAX_STRING_SIZE> message) = 0;
 
 private:

--- a/Lib/Src/CDispatcher.cpp
+++ b/Lib/Src/CDispatcher.cpp
@@ -202,11 +202,11 @@ void CDispatcher::processComChannels()
 {
     for (int channel = 0; channel < m_comchannel_count; channel++)
     {
-        while (mp_comchannels[channel]->isCommandAvailable())
+        while (mp_comchannels[channel]->isDataAvailable())
         {
             bool b_command_recognised;
             etl::string<MAX_STRING_SIZE> command =
-                mp_comchannels[channel]->getCommand();
+                mp_comchannels[channel]->getData();
             /* first check if this command is for CDispatcher. */
             b_command_recognised = newCommand(command, mp_comchannels[channel]);
             uint8_t controller = 0;

--- a/Lib/Src/CUartCom.cpp
+++ b/Lib/Src/CUartCom.cpp
@@ -272,7 +272,7 @@ etl::string<MAX_STRING_SIZE> CUartCom::getString()
 }
 
 /**
- * @brief Check if the queue has any commands to read
+ * @brief Check if RX Queue is empty
  * @return True if the queue is not empty
  */
 bool CUartCom::isDataAvailable()
@@ -286,14 +286,14 @@ bool CUartCom::isDataAvailable()
 
 /**
  * @brief Get and delete the first element in the RX queue
- * @return Command as string
+ * @return Data as string
  */
 etl::string<MAX_STRING_SIZE> CUartCom::getData()
 {
     if (m_rx_queue.size() > 0)
     {
-        etl::string<MAX_STRING_SIZE> command = m_rx_queue.get();
-        return command;
+        etl::string<MAX_STRING_SIZE> data = m_rx_queue.get();
+        return data;
     }
     return "";
 }

--- a/Lib/Src/CUartCom.cpp
+++ b/Lib/Src/CUartCom.cpp
@@ -275,7 +275,7 @@ etl::string<MAX_STRING_SIZE> CUartCom::getString()
  * @brief Check if the queue has any commands to read
  * @return True if the queue is not empty
  */
-bool CUartCom::isCommandAvailable()
+bool CUartCom::isDataAvailable()
 {
     if (m_rx_queue.size() > 0)
     {
@@ -288,7 +288,7 @@ bool CUartCom::isCommandAvailable()
  * @brief Get and delete the first element in the RX queue
  * @return Command as string
  */
-etl::string<MAX_STRING_SIZE> CUartCom::getCommand()
+etl::string<MAX_STRING_SIZE> CUartCom::getData()
 {
     if (m_rx_queue.size() > 0)
     {


### PR DESCRIPTION
To make the IComChannel more generic, the methods isCommandAvailable() and getCommand() are now isDataAvailable() and getData()