### PR TITLE
Feature/nu uart comms

### DIFF
--- a/Lib/Inc/CFIFOBuffer.h
+++ b/Lib/Inc/CFIFOBuffer.h
@@ -28,6 +28,10 @@ public:
     bool put(T data)
     {
         bool b_success = false;
+        /**
+         * @note Disable interrupts while calling put() to avoid simultaneous
+         * access to the buffer and its variables.
+         */
         __disable_irq();
         if (m_count < BUF_SIZE)
         {

--- a/Lib/Inc/CFIFOBuffer.h
+++ b/Lib/Inc/CFIFOBuffer.h
@@ -10,6 +10,8 @@
 #ifndef CFIFOBUFFER_H_
 #define CFIFOBUFFER_H_
 
+#include "main.h"
+
 template <typename T, uint16_t BUF_SIZE>
 class CFIFOBuffer
 {
@@ -26,6 +28,7 @@ public:
     bool put(T data)
     {
         bool b_success = false;
+        __disable_irq();
         if (m_count < BUF_SIZE)
         {
             m_rx_buffer[m_head] = data;
@@ -36,6 +39,7 @@ public:
             m_count++;
             b_success = true;
         }
+        __enable_irq();
         return b_success;
     }
 

--- a/Lib/Inc/CUartCom.h
+++ b/Lib/Inc/CUartCom.h
@@ -21,11 +21,11 @@
 #define MAX_UART_ENGINES 8
 
 /**
-*@note TX_BUF_SIZE needs to be greater than MAX_STRING_SIZE
-*/
-#define TX_BUF_SIZE      (MAX_STRING_SIZE + 1)
-#define RX_QUEUE_SIZE    100
-#define TX_QUEUE_SIZE    100
+ *@note TX_BUF_SIZE needs to be greater than MAX_STRING_SIZE
+ */
+#define TX_BUF_SIZE   500
+#define RX_QUEUE_SIZE 100
+#define TX_QUEUE_SIZE 100
 
 class CUartCom : public IComChannel
 {

--- a/Lib/Inc/CUartCom.h
+++ b/Lib/Inc/CUartCom.h
@@ -37,7 +37,8 @@ public:
     void startRx();
     bool send(const etl::string<MAX_STRING_SIZE> msg);
     bool isDataAvailable();
-    etl::string<MAX_STRING_SIZE> getData();
+    uint8_t getData();
+
     void uartRxHandler(UART_HandleTypeDef *p_huart);
     void uartTxHandler(UART_HandleTypeDef *p_huart);
 
@@ -51,7 +52,6 @@ private:
     void updateTxBuffer();
     void endTx();
     bool transmit();
-    etl::string<MAX_STRING_SIZE> getString();
     enum uart_status
     {
         IDLE,

--- a/Lib/Inc/IComChannel.h
+++ b/Lib/Inc/IComChannel.h
@@ -28,7 +28,7 @@ public:
     };
 
     virtual bool isDataAvailable() = 0;
-    virtual etl::string<MAX_STRING_SIZE> getData() = 0;
+    virtual uint8_t getData() = 0;
     virtual bool send(etl::string<MAX_STRING_SIZE> message) = 0;
 
 private:

--- a/Lib/Src/CDispatcher.cpp
+++ b/Lib/Src/CDispatcher.cpp
@@ -205,8 +205,9 @@ void CDispatcher::processComChannels()
         while (mp_comchannels[channel]->isDataAvailable())
         {
             bool b_command_recognised;
-            etl::string<MAX_STRING_SIZE> command =
-                mp_comchannels[channel]->getData();
+            // TODO: Change this method to work with the future command parser
+            etl::string<MAX_STRING_SIZE> command = "";
+            //    mp_comchannels[channel]->getData();
             /* first check if this command is for CDispatcher. */
             b_command_recognised = newCommand(command, mp_comchannels[channel]);
             uint8_t controller = 0;

--- a/Lib/Src/CUartCom.cpp
+++ b/Lib/Src/CUartCom.cpp
@@ -98,33 +98,14 @@ void CUartCom::stopRx()
 }
 
 /**
- * @brief Add string to the TX Queue and start transmission if UART is IDLE
+ * @brief Send string message
  * @param msg Message to send.
- * @return True if message was added to the queue. If transmission is attempted,
- * it returns true if it was successful.
+ * @return True if successful
  */
 bool CUartCom::send(etl::string<MAX_STRING_SIZE> msg)
 {
-    bool b_success = false;
-
-    CUartCom::tx_data_t data;
-
-    // Copy message to uint8_t buffer in data object
-    if ((m_tx_queue.size() < TX_QUEUE_SIZE) && (msg.empty() == false))
-    {
-        strcpy(data.buffer, msg.c_str());
-        data.length = msg.length();
-        if (m_tx_queue.put(data))
-        {
-            b_success = true;
-        }
-    }
-
-    // Start transmission only if UART is idle
-    if (m_status == IDLE)
-    {
-        b_success = transmit();
-    }
+    uint32_t msg_len = msg.length();
+    bool b_success = send((uint8_t *)msg.c_str(), msg_len);
     return b_success;
 }
 
@@ -139,23 +120,22 @@ bool CUartCom::send(uint8_t *p_data_buf, uint32_t len)
 {
     bool b_success = false;
 
-    // Data object to be added to the queue
-    CUartCom::tx_data_t data;
+    CUartCom::tx_data_t data_obj;
 
-    data.length = len;
-    // Add data to buffer in data object
+    data_obj.length = len;
+    // Store data in internal data_obj buffer
     for (uint32_t i = 0; i < len; i++)
     {
-        data.buffer[i] = p_data_buf[i];
+        data_obj.buffer[i] = p_data_buf[i];
     }
 
-    // Insert data into TX queue
-    if (m_tx_queue.put(data))
+    // Insert data_obj into TX queue
+    if (m_tx_queue.put(data_obj))
     {
         b_success = true;
     }
 
-    // Start transmission only if UART is idle
+    // Start transmission only if UART is not transmitting already
     if (m_status == IDLE)
     {
         b_success = transmit();

--- a/Lib/Src/CUartCom.cpp
+++ b/Lib/Src/CUartCom.cpp
@@ -113,8 +113,7 @@ bool CUartCom::send(etl::string<MAX_STRING_SIZE> msg)
  * @brief Add data to the TX Queue and start transmission if possible
  * @param Pointer to data buffer
  * @param Length of the data buffer (in bytes)
- * @return True if message was added to the queue and transmission started
- * successfully.
+ * @return True if message was added to the queue
  */
 bool CUartCom::send(uint8_t *p_data_buf, uint32_t len)
 {
@@ -138,7 +137,7 @@ bool CUartCom::send(uint8_t *p_data_buf, uint32_t len)
     // Start transmission only if UART is not transmitting already
     if (m_status == IDLE)
     {
-        b_success = transmit();
+        transmit();
     }
     return b_success;
 }

--- a/Lib/Src/CUartCom.cpp
+++ b/Lib/Src/CUartCom.cpp
@@ -196,7 +196,7 @@ void CUartCom::uartRxHandler(UART_HandleTypeDef *p_huart)
 {
     if (!m_rx_queue.put(m_rx_byte))
     {
-        send("[ERROR]: Data exceeds max. buffer capacity\n");
+        send("[ERROR]: Buffer overflow -> m_rx_queue\n");
         m_rx_queue.reset();
     }
 


### PR DESCRIPTION
Fix #63 and #64. 
- The CUartCom class now works with bytes instead of strings. 
- Overloaded send() method works with strings or buffer of uint8_t
- UartRxHandler() method is significantly simpler 