### PR TITLE
refactor: add stopRx() method

### DIFF
--- a/Lib/Inc/CUartCom.h
+++ b/Lib/Inc/CUartCom.h
@@ -50,6 +50,7 @@ public:
 private:
     void updateTxBuffer();
     void endTx();
+    void stopRx();
     bool transmit();
     etl::string<MAX_STRING_SIZE> getString();
     enum uart_status


### PR DESCRIPTION
Add stopRx method to make things easier to read. This method uses a HAL function that disables UART RX interrupts. 