### PR TITLE
Feature/nu json parser

### DIFF
--- a/Lib/Inc/CParser.h
+++ b/Lib/Inc/CParser.h
@@ -50,7 +50,9 @@ public:
         ADD_VALUE,
         VALUE_ADDED,
         END_VALUES,
-        PARSING_OK,
+        COMMAND_OK,
+        ERROR_MAX_ARGS,
+        ERROR_NESTED_JSON,
         ERROR
     } parser_state_t;
 

--- a/Lib/Inc/CParser.h
+++ b/Lib/Inc/CParser.h
@@ -78,12 +78,13 @@ private:
     void getTokens(const etl::string<MAX_STRING_SIZE> &string);
     void endToken(CParser::token_t &token);
 
-    // Private variables
+    // Private member variables
     uint8_t m_argument_counter = 0;
-    etl::vector<token_t, MAX_TOKENS> m_tokens;
-    uint16_t m_token_counter = 0;
     etl::string<MAX_STRING_SIZE> m_command_name;
     float m_arguments[MAX_ARGUMENT_COUNT];
+
+    etl::vector<token_t, MAX_TOKENS> m_tokens;
+    uint16_t m_token_counter = 0;
     parser_state_t m_status = IDLE;
 };
 

--- a/Lib/Inc/CParser.h
+++ b/Lib/Inc/CParser.h
@@ -37,11 +37,10 @@ public:
         START_ARRAY_OP,
         END_ARRAY_OP,
         ARGUMENT_DELIMITER,
-        KEY_VALUE_DIV,
-        INVALID
+        KEY_VALUE_DIV
     } token_type_t;
 
-    typedef enum PARSING_STATUS
+    typedef enum PARSING_STATE
     {
         IDLE,
         BEGIN_KEY,
@@ -53,7 +52,7 @@ public:
         END_VALUES,
         PARSING_OK,
         ERROR
-    } parser_status_t;
+    } parser_state_t;
 
     typedef struct token
     {
@@ -64,7 +63,7 @@ public:
 
     // Public methods
     CParser();
-    CParser::parser_status_t parse(const etl::string<MAX_STRING_SIZE> &string);
+    CParser::parser_state_t parse(const etl::string<MAX_STRING_SIZE> &string);
     etl::string<MAX_STRING_SIZE> getName() const;
     unsigned int getArgumentCount() const;
     float operator[](unsigned int index);
@@ -83,7 +82,7 @@ private:
     uint16_t m_token_counter = 0;
     etl::string<MAX_STRING_SIZE> m_command_name;
     float m_arguments[MAX_ARGUMENT_COUNT];
-    parser_status_t m_status = IDLE;
+    parser_state_t m_status = IDLE;
 };
 
 #endif /* CPARSER_H_ */

--- a/Lib/Inc/CParser.h
+++ b/Lib/Inc/CParser.h
@@ -1,0 +1,89 @@
+/**
+ * @file CParser.h
+ *
+ */
+/*
+ *  Created on: Apr 4, 2022
+ *      Author: niuslar
+ */
+
+#ifndef CPARSER_H_
+#define CPARSER_H_
+
+#include "../etl/string.h"
+#include "../etl/vector.h"
+#include "CFIFOBuffer.h"
+#include "IComChannel.h"
+#include "ICommand.h"
+#include "main.h"
+
+#define MAX_TOKENS 60
+
+#ifndef MAX_STRING_SIZE
+#    define MAX_STRING_SIZE 100
+#endif
+
+class CParser : public ICommand
+{
+public:
+    typedef enum TOKEN_TYPES
+    {
+        WHITESPACE,
+        INTEGER,
+        FLOAT,
+        STRING_LITERAL,
+        BEGIN_OPERATOR,
+        END_OPERATOR,
+        START_ARRAY_OP,
+        END_ARRAY_OP,
+        ARGUMENT_DELIMITER,
+        KEY_VALUE_DIV,
+        INVALID
+    } token_type_t;
+
+    typedef enum PARSING_STATUS
+    {
+        IDLE,
+        BEGIN_KEY,
+        END_KEY,
+        BEGIN_VALUE,
+        BEGIN_ARRAY,
+        ADD_VALUE,
+        VALUE_ADDED,
+        END_VALUES,
+        PARSING_OK,
+        ERROR
+    } parser_status_t;
+
+    typedef struct token
+    {
+        token_type_t type = WHITESPACE;
+        etl::string<MAX_STRING_SIZE> text;
+
+    } token_t;
+
+    // Public methods
+    CParser();
+    CParser::parser_status_t parse(const etl::string<MAX_STRING_SIZE> &string);
+    etl::string<MAX_STRING_SIZE> getName() const;
+    unsigned int getArgumentCount() const;
+    float operator[](unsigned int index);
+
+private:
+    // Private methods
+    void addOperator(CParser::token_t &token,
+                     CParser::token_type_t operator_type,
+                     char character);
+    void getTokens(const etl::string<MAX_STRING_SIZE> &string);
+    void endToken(CParser::token_t &token);
+
+    // Private variables
+    uint8_t m_argument_counter = 0;
+    etl::vector<token_t, MAX_TOKENS> m_tokens;
+    uint16_t m_token_counter = 0;
+    etl::string<MAX_STRING_SIZE> m_command_name;
+    float m_arguments[MAX_ARGUMENT_COUNT];
+    parser_status_t m_status = IDLE;
+};
+
+#endif /* CPARSER_H_ */

--- a/Lib/Inc/ICommand.h
+++ b/Lib/Inc/ICommand.h
@@ -21,7 +21,7 @@
 class ICommand
 {
 public:
-    ICommand();
+    ICommand() {}
 
     /**
      * @brief Get name of the last parsed command.

--- a/Lib/Inc/ICommand.h
+++ b/Lib/Inc/ICommand.h
@@ -28,7 +28,7 @@ public:
      *
      * @return Name of the last parsed command.
      */
-    virtual etl::string<MAX_STRING_SIZE> *getName() const = 0;
+    virtual etl::string<MAX_STRING_SIZE> getName() const = 0;
 
     /**
      * @brief Get number of arguments.

--- a/Lib/Src/CParser.cpp
+++ b/Lib/Src/CParser.cpp
@@ -18,7 +18,7 @@ CParser::CParser() {}
 /**
  * @brief Parse string
  * @param String to be parsed
- * @return Parsing status
+ * @return Last parsing state
  */
 CParser::parser_state_t CParser::parse(
     const etl::string<MAX_STRING_SIZE> &string)
@@ -44,7 +44,7 @@ CParser::parser_state_t CParser::parse(
                 }
                 else
                 {
-                	m_status = ERROR_NESTED_JSON;
+                    m_status = ERROR_NESTED_JSON;
                 }
                 break;
             case STRING_LITERAL:
@@ -77,7 +77,6 @@ CParser::parser_state_t CParser::parse(
             case FLOAT:
                 if (m_status == BEGIN_VALUE)
                 {
-                    // We need to convert string to float
                     float number = std::stof(m_tokens[i].text.c_str());
                     m_arguments[m_argument_counter] = number;
                     m_argument_counter++;
@@ -119,7 +118,7 @@ CParser::parser_state_t CParser::parse(
 }
 
 /**
- * @brief Retrieve tokens from a string
+ * @brief Process string to get tokens
  * @param String to be tokenised
  */
 void CParser::getTokens(const etl::string<MAX_STRING_SIZE> &string)
@@ -254,6 +253,7 @@ void CParser::endToken(CParser::token_t &token)
  * @brief Add operator token
  * @param token
  * @param operator type
+ * @param character to be appended
  */
 void CParser::addOperator(CParser::token_t &token,
                           CParser::token_type_t operator_type,
@@ -273,8 +273,9 @@ void CParser::addOperator(CParser::token_t &token,
 }
 
 /**
- * @brief Get command name
- * @return etl::string with command name
+ * @brief Get name of the last parsed command.
+ *
+ * @return Name of the last parsed command.
  */
 etl::string<MAX_STRING_SIZE> CParser::getName() const
 {
@@ -282,7 +283,9 @@ etl::string<MAX_STRING_SIZE> CParser::getName() const
 }
 
 /**
- * @brief Get arguments for a given command
+ * @brief Get number of arguments.
+ *
+ * @return Number of parsed arguments.
  */
 unsigned int CParser::getArgumentCount() const
 {
@@ -290,7 +293,11 @@ unsigned int CParser::getArgumentCount() const
 }
 
 /**
- * @brief get argument from index
+ * @brief Access parsed arguments by index of their position in the command
+ * string.
+ *
+ * @param index Position of the argument to be accessed. Zero-based index.
+ * @return Value of the argument at the requested index.
  */
 float CParser::operator[](unsigned int index)
 {

--- a/Lib/Src/CParser.cpp
+++ b/Lib/Src/CParser.cpp
@@ -20,7 +20,7 @@ CParser::CParser() {}
  * @param String to be parsed
  * @return Parsing status
  */
-CParser::parser_status_t CParser::parse(
+CParser::parser_state_t CParser::parse(
     const etl::string<MAX_STRING_SIZE> &string)
 {
     // Reset command variables
@@ -158,12 +158,6 @@ void CParser::getTokens(const etl::string<MAX_STRING_SIZE> &string)
                     current_token.type = FLOAT;
                     current_token.text.append(1, current_char);
                 }
-                else
-                {
-                    current_token.type = INVALID;
-                    current_token.text.append(1, current_char);
-                    endToken(current_token);
-                }
                 break;
 
             // Token end characters
@@ -223,12 +217,6 @@ void CParser::getTokens(const etl::string<MAX_STRING_SIZE> &string)
                     current_token.type == FLOAT)
                 {
                     endToken(current_token);
-                    current_token.type = INVALID;
-                    current_token.text.append(1, current_char);
-                }
-                else
-                {
-                    current_token.text.append(1, current_char);
                 }
                 break;
         }

--- a/Lib/Src/CParser.cpp
+++ b/Lib/Src/CParser.cpp
@@ -8,7 +8,7 @@
 
 #include "CParser.h"
 
-#define ERROR_VALUE (999.99)
+#define ERROR_VALUE (0.00)
 
 /**
  * @brief Constructor

--- a/Lib/Src/CParser.cpp
+++ b/Lib/Src/CParser.cpp
@@ -42,6 +42,10 @@ CParser::parser_state_t CParser::parse(
                 {
                     m_status = BEGIN_KEY;
                 }
+                else
+                {
+                	m_status = ERROR_NESTED_JSON;
+                }
                 break;
             case STRING_LITERAL:
                 if (m_status == BEGIN_KEY)
@@ -61,10 +65,6 @@ CParser::parser_state_t CParser::parse(
                 if (m_status == BEGIN_ARRAY || m_status == VALUE_ADDED)
                 {
                     m_status = ADD_VALUE;
-                }
-                else
-                {
-                    m_status = ERROR;
                 }
                 break;
             case KEY_VALUE_DIV:
@@ -92,6 +92,10 @@ CParser::parser_state_t CParser::parse(
                         m_argument_counter++;
                         m_status = VALUE_ADDED;
                     }
+                    else
+                    {
+                        m_status = ERROR_MAX_ARGS;
+                    }
                 }
                 break;
             case END_ARRAY_OP:
@@ -99,10 +103,11 @@ CParser::parser_state_t CParser::parse(
                 {
                     m_status = END_VALUES;
                 }
+                break;
             case END_OPERATOR:
                 if (m_status == END_VALUES)
                 {
-                    m_status = PARSING_OK;
+                    m_status = COMMAND_OK;
                 }
                 break;
             default:
@@ -217,6 +222,10 @@ void CParser::getTokens(const etl::string<MAX_STRING_SIZE> &string)
                     current_token.type == FLOAT)
                 {
                     endToken(current_token);
+                }
+                else
+                {
+                    current_token.text.append(1, current_char);
                 }
                 break;
         }

--- a/Lib/Src/CParser.cpp
+++ b/Lib/Src/CParser.cpp
@@ -1,0 +1,305 @@
+/**
+ * @file CParser.cpp
+ */
+/*
+ * Created on : Apr 4, 2022
+ * Author : niuslar
+ */
+
+#include "CParser.h"
+
+#define ERROR_VALUE (999.99)
+
+/**
+ * @brief Constructor
+ */
+CParser::CParser() {}
+
+/**
+ * @brief Parse string
+ * @param String to be parsed
+ * @return Parsing status
+ */
+CParser::parser_status_t CParser::parse(
+    const etl::string<MAX_STRING_SIZE> &string)
+{
+    // Reset command variables
+    m_status = IDLE;
+    m_argument_counter = 0;
+    m_command_name = "";
+
+    // Get tokens from string
+    getTokens(string);
+
+    for (uint16_t i = 0; i < m_token_counter; i++)
+    {
+        token_t current_token = m_tokens[i];
+
+        switch (current_token.type)
+        {
+            case BEGIN_OPERATOR:
+                if (m_status == IDLE)
+                {
+                    m_status = BEGIN_KEY;
+                }
+                break;
+            case STRING_LITERAL:
+                if (m_status == BEGIN_KEY)
+                {
+                    // Store key
+                    m_command_name = m_tokens[i].text;
+                    m_status = END_KEY;
+                }
+                break;
+            case START_ARRAY_OP:
+                if (m_status == BEGIN_VALUE)
+                {
+                    m_status = BEGIN_ARRAY;
+                }
+                break;
+            case ARGUMENT_DELIMITER:
+                if (m_status == BEGIN_ARRAY || m_status == VALUE_ADDED)
+                {
+                    m_status = ADD_VALUE;
+                }
+                else
+                {
+                    m_status = ERROR;
+                }
+                break;
+            case KEY_VALUE_DIV:
+                if (m_status == END_KEY)
+                {
+                    m_status = BEGIN_VALUE;
+                }
+                break;
+            case INTEGER:
+            case FLOAT:
+                if (m_status == BEGIN_VALUE)
+                {
+                    // We need to convert string to float
+                    float number = std::stof(m_tokens[i].text.c_str());
+                    m_arguments[m_argument_counter] = number;
+                    m_argument_counter++;
+                    m_status = END_VALUES;
+                }
+                else if (m_status == BEGIN_ARRAY || m_status == ADD_VALUE)
+                {
+                    if (m_argument_counter < MAX_ARGUMENT_COUNT)
+                    {
+                        float number = std::stof(m_tokens[i].text.c_str());
+                        m_arguments[m_argument_counter] = number;
+                        m_argument_counter++;
+                        m_status = VALUE_ADDED;
+                    }
+                }
+                break;
+            case END_ARRAY_OP:
+                if (m_status == VALUE_ADDED)
+                {
+                    m_status = END_VALUES;
+                }
+            case END_OPERATOR:
+                if (m_status == END_VALUES)
+                {
+                    m_status = PARSING_OK;
+                }
+                break;
+            default:
+                m_status = ERROR;
+        }
+    }
+
+    return m_status;
+}
+
+/**
+ * @brief Retrieve tokens from a string
+ * @param String to be tokenised
+ */
+void CParser::getTokens(const etl::string<MAX_STRING_SIZE> &string)
+{
+    // Reset variables
+    m_tokens.clear();
+    m_token_counter = 0;
+    token_t current_token;
+
+    // Loop through characters in string
+    for (char current_char : string)
+    {
+        switch (current_char)
+        {
+            // Numbers
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                if (current_token.type == WHITESPACE)
+                {
+                    current_token.type = INTEGER;
+                    current_token.text.append(1, current_char);
+                }
+                else
+                {
+                    current_token.text.append(1, current_char);
+                }
+                break;
+
+            // Check if it is a float
+            case '.':
+                if (current_token.type == INTEGER)
+                {
+                    current_token.type = FLOAT;
+                    current_token.text.append(1, current_char);
+                }
+                else
+                {
+                    current_token.type = INVALID;
+                    current_token.text.append(1, current_char);
+                    endToken(current_token);
+                }
+                break;
+
+            // Token end characters
+            case ' ':
+            case '\t':
+                if (current_token.type == STRING_LITERAL)
+                {
+                    current_token.text.append(1, current_char);
+                }
+                else
+                {
+                    endToken(current_token);
+                }
+                break;
+            case '\n':
+            case '\r':
+            case '\0':
+                endToken(current_token);
+                break;
+
+            // Operators
+            case ':':
+                addOperator(current_token, KEY_VALUE_DIV, current_char);
+                break;
+            case '{':
+                addOperator(current_token, BEGIN_OPERATOR, current_char);
+                break;
+            case '}':
+                addOperator(current_token, END_OPERATOR, current_char);
+                break;
+            case '[':
+                addOperator(current_token, START_ARRAY_OP, current_char);
+                break;
+            case ']':
+                addOperator(current_token, END_ARRAY_OP, current_char);
+                break;
+            case ',':
+                addOperator(current_token, ARGUMENT_DELIMITER, current_char);
+                break;
+
+            // String literal
+            case '"':
+                if (current_token.type != STRING_LITERAL)
+                {
+                    endToken(current_token);
+                    current_token.type = STRING_LITERAL;
+                }
+                else
+                {
+                    endToken(current_token);
+                }
+                break;
+
+            default:
+                if (current_token.type == WHITESPACE ||
+                    current_token.type == INTEGER ||
+                    current_token.type == FLOAT)
+                {
+                    endToken(current_token);
+                    current_token.type = INVALID;
+                    current_token.text.append(1, current_char);
+                }
+                else
+                {
+                    current_token.text.append(1, current_char);
+                }
+                break;
+        }
+    }
+}
+
+/**
+ * @brief Add token to m_tokens vector
+ * @param token to be added
+ */
+void CParser::endToken(CParser::token_t &token)
+{
+    if (token.type != WHITESPACE)
+    {
+        if (token.text.empty() == false)
+        {
+            m_tokens.push_back(token);
+            m_token_counter++;
+        }
+    }
+    token.type = WHITESPACE;
+    token.text.clear();
+}
+
+/**
+ * @brief Add operator token
+ * @param token
+ * @param operator type
+ */
+void CParser::addOperator(CParser::token_t &token,
+                          CParser::token_type_t operator_type,
+                          char character)
+{
+    if (token.type != STRING_LITERAL)
+    {
+        endToken(token);
+        token.type = operator_type;
+        token.text.append(1, character);
+        endToken(token);
+    }
+    else
+    {
+        token.text.append(1, character);
+    }
+}
+
+/**
+ * @brief Get command name
+ * @return etl::string with command name
+ */
+etl::string<MAX_STRING_SIZE> CParser::getName() const
+{
+    return m_command_name;
+}
+
+/**
+ * @brief Get arguments for a given command
+ */
+unsigned int CParser::getArgumentCount() const
+{
+    return m_argument_counter;
+}
+
+/**
+ * @brief get argument from index
+ */
+float CParser::operator[](unsigned int index)
+{
+    if (index < MAX_ARGUMENT_COUNT)
+    {
+        return m_arguments[index];
+    }
+    return ERROR_VALUE;
+}


### PR DESCRIPTION
This is a partial JSON parser. 
It works with one of the following formats: 
{"commandName":[arg1,arg2,arg3,arg4]} for multiple arguments  or
{"commandName:arg1}   when there's only one argument. 

This parser does not support nested objects, that is why I call it a "partial" JSON parser. 

The parser follows this state diagram: 
![parser_states(1)](https://user-images.githubusercontent.com/34103285/165834079-725e4e39-10b0-4fdc-9791-8cb94f4175e2.png)

As the note says, if the final state is not COMMAND_OK, it means there was an error and the parser will return the last state it reached. 
I tested it with a list of commands and I think it is easy to identify what is wrong with the command based on the last state. 

Here is the list of commands I tried and the results I got:
## Commands: 
```
{"command1":23}				 
{"command2":44.3}
{"command3":[22,44,77]}
{"command4":[33,44,55,66.5,77.5]}
{"command5":[33 ,44 ,55 ,66.5 ,77.5 ]} 
{command6:45}
{"command7":[55,77,33,55,33,22,34,4,3,23,2]}
{"command8":
>command9(12,53,21);
{"command10":{"command11":[10,34]}}
{"command12":"33,22,1134"}
```

## Results:
```
Command name: command1
Argument 1: 23.0
Command name: command2
Argument 1: 44.3
Command name: command3
Argument 1: 22.0
Argument 2: 44.0
Argument 3: 77.0
Command name: command4
Argument 1: 33.0
Argument 2: 44.0
Argument 3: 55.0
Argument 4: 66.5
Argument 5: 77.5
Command name: command5
Argument 1: 33.0
Argument 2: 44.0
Argument 3: 55.0
Argument 4: 66.5
Argument 5: 77.5
BEGIN_KEY
ERROR_MAX_ARGS
BEGIN_VALUE
IDLE                                                                                                  
ERROR_NESTED_JSON                                                                                     
BEGIN_VALUE 
```

## Note: 
While testing I noticed the following bug:
- If I send the commands one by one, I get the expected results, but if I send all the commands at once, the results get scrambled.
- Example: 
```
Command name: command1
Argument 1: 23.0
Command name: command2
Argument 1: 44.3
Command name: command3
Argument 1: 22.0
Argument 2: 44.0
Argument 3: 77.0
Command name: command4
Argument 1: 33.0
Argument 2: 44.0
Argument 3: 55.0
Argument 4: 66.5
Command name: command5
Argument 1: 33.0                       <-- Command5 should have 5 arguments, not 1
77.5                      <-- This is the 5th argument of command5
BEGIN_KEYERROR_MAX_ARGS                 <-- Missing new-line character
BEGIN_VALUE
IDLE
ERROR_NESTED_JSON
BEGIN_VALUE              
```
I'm including the following code in cpp_link.cpp to get those results:
```
// New includes
#include "CParser.h"
#include "../etl/to_string.h"

//Then in cpp_main() I'm adding:

        g_debug_uart.init(&huart2);
        g_debug_uart.startRx();

        // Infinite Loop
        while (1)
        {
            if (g_debug_uart.isDataAvailable())
            {
                CParser::parser_state_t state =
                    g_parser.parse(g_debug_uart.getData());
                if (state == CParser::COMMAND_OK)
                {
                    g_debug_uart.send("Command name: ");
                    g_debug_uart.send(g_parser.getName());
                    g_debug_uart.send("\n");
                    unsigned int arg_count = g_parser.getArgumentCount();
                    for (unsigned int i = 0; i < arg_count; i++)
                    {
                        g_debug_uart.send("Argument ");
                        etl::string<10> index;
                        etl::to_string((i + 1), index);
                        g_debug_uart.send(index);
                        g_debug_uart.send(": ");
                        etl::string<30> argument;
                        etl::to_string(g_parser[i],
                                       argument,
                                       etl::format_spec().precision(1),
                                       true);
                        g_debug_uart.send(argument);
                        g_debug_uart.send("\n");
                    }
                }
                else
                {
                    g_debug_uart.send(parsing_state[state]);
                    g_debug_uart.send("\n");
                }
            }
        }
```


My guess is that this is a bug in the CUartCom class. Need further testing. 

