### PR TITLE
Fix/nu uart bufer overflow

### DIFF
--- a/Lib/Inc/CUartCom.h
+++ b/Lib/Inc/CUartCom.h
@@ -18,10 +18,10 @@
 #include "usart.h"
 
 #define UART_TIMEOUT      100
-#define MAX_RX_QUEUE_SIZE 40
-#define MAX_TX_QUEUE_SIZE 40
+#define MAX_RX_QUEUE_SIZE 50
+#define MAX_TX_QUEUE_SIZE 100
 #define MAX_UART_ENGINES  8
-#define TX_BUF_SIZE       (MAX_STRING_SIZE + 1)
+#define TX_BUF_SIZE       70
 #define RX_BUF_SIZE       60
 
 class CUartCom : public IComChannel

--- a/Lib/Inc/CUartCom.h
+++ b/Lib/Inc/CUartCom.h
@@ -19,7 +19,7 @@
 
 #define UART_TIMEOUT      100
 #define MAX_RX_QUEUE_SIZE 50
-#define MAX_TX_QUEUE_SIZE 100
+#define MAX_TX_QUEUE_SIZE 3000  // size in bytes
 #define MAX_UART_ENGINES  8
 #define TX_BUF_SIZE       70
 #define RX_BUF_SIZE       60
@@ -36,6 +36,7 @@ public:
 
     void startRx();
     bool send(const etl::string<MAX_STRING_SIZE> msg);
+    bool send(uint8_t *p_data_buf, uint32_t len);
     bool isDataAvailable();
     etl::string<MAX_STRING_SIZE> getData();
     void uartRxHandler(UART_HandleTypeDef *p_huart);
@@ -63,11 +64,11 @@ private:
     uint8_t m_status = IDLE;
     CGpioWrapper m_uart_de_pin;
     CFIFOBuffer<char, RX_BUF_SIZE> m_rx_buffer;
-    char m_tx_buffer[TX_BUF_SIZE] = {0};
+    uint8_t m_tx_char;
     uint8_t m_tx_msg_length = 0;
     uint8_t m_rx_char;
     CFIFOBuffer<etl::string<MAX_STRING_SIZE>, MAX_RX_QUEUE_SIZE> m_rx_queue;
-    CFIFOBuffer<etl::string<MAX_STRING_SIZE>, MAX_TX_QUEUE_SIZE> m_tx_queue;
+    CFIFOBuffer<uint8_t, MAX_TX_QUEUE_SIZE> m_tx_queue;
 };
 
 #endif /* CUARTCOM_H_ */

--- a/Lib/Src/CUartCom.cpp
+++ b/Lib/Src/CUartCom.cpp
@@ -109,11 +109,14 @@ bool CUartCom::send(etl::string<MAX_STRING_SIZE> msg)
     // Add message to queue
     if (m_tx_queue.size() <= MAX_TX_QUEUE_SIZE && (msg.empty() == false))
     {
-        if (m_tx_queue.put(msg) == false)
+        if (m_tx_queue.put(msg) == true)
+        {
+            b_success = true;
+        }
+        else
         {
             send("Error: Buffer overflow -> TX Queue\n");
         }
-        b_success = true;
     }
 
     // Start transmission only if UART is idle

--- a/Lib/Src/CUartCom.cpp
+++ b/Lib/Src/CUartCom.cpp
@@ -109,7 +109,10 @@ bool CUartCom::send(etl::string<MAX_STRING_SIZE> msg)
     // Add message to queue
     if (m_tx_queue.size() <= MAX_TX_QUEUE_SIZE && (msg.empty() == false))
     {
-        m_tx_queue.put(msg);
+        if (m_tx_queue.put(msg) == false)
+        {
+            send("Error: Buffer overflow -> TX Queue\n");
+        }
         b_success = true;
     }
 
@@ -208,14 +211,20 @@ void CUartCom::uartRxHandler(UART_HandleTypeDef *p_huart)
             etl::string<MAX_STRING_SIZE> rx_string = getString();
             if (m_rx_queue.size() <= MAX_RX_QUEUE_SIZE && !rx_string.empty())
             {
-                m_rx_queue.put(rx_string);
+                if (m_rx_queue.put(rx_string) == false)
+                {
+                    send("Error: Buffer overflow -> RX Queue\n");
+                }
             }
         }
         len_counter = 0;
     }
     else
     {
-        m_rx_buffer.put((char)m_rx_char);
+        if (m_rx_buffer.put((char)m_rx_char) == false)
+        {
+            send("Error: Buffer overflow -> RX BUFFER\n");
+        }
         len_counter++;
     }
 

--- a/Lib/Src/CUartCom.cpp
+++ b/Lib/Src/CUartCom.cpp
@@ -115,22 +115,18 @@ bool CUartCom::send(etl::string<MAX_STRING_SIZE> msg)
  * @brief Add data to the TX Queue and start transmission if possible
  * @param p_data_buf Reference to array of uint8_t data
  * @param len Size of data that needs to be stored
- * @return True if data was added to the queue
+ * @return True if data was added to the queue, false in case of buffer overflow
  */
 bool CUartCom::send(uint8_t *p_data_buf, uint32_t len)
 {
-    bool b_success = false;
+    bool b_success = true;
 
     // Store data in tx_queue
     for (uint32_t i = 0; i < len; i++)
     {
         if (m_tx_queue.put(p_data_buf[i]) == false)
         {
-            send("Error: buffer overflow-> TX queue");
-        }
-        else
-        {
-            b_success = true;
+            b_success = false;
         }
     }
 


### PR DESCRIPTION
When the send() method is call too many times, too quickly, it can lead to a buffer overflow. 
I increased the buffers  and queues size to prevent this from happening, but it can still happen. 
Because of this I added some error messages to make it easy to identify what's causing problems. 