### PR TITLE
refactor (CMockHardwareMap): newCommand() method for clarity

### DIFF
--- a/Hardware/CMockHardwareMap.h
+++ b/Hardware/CMockHardwareMap.h
@@ -19,6 +19,15 @@
 class CMockHardwareMap : public IHardwareMap, public CController
 {
 public:
+    typedef enum COMMAND_ERROR_CODE_T
+    {
+        COMMAND_OK = 0,
+        ERROR_ARG_COUNT,      // wrong number of arguments
+        ERROR_OUT_OF_BOUNDS,  // arguments out of bounds
+        ERROR_TYPE_MISMATCH   // argument is wrong type, e.g. float when int
+                              // expected
+    } command_error_code_t;
+
     CMockHardwareMap(etl::string<MAX_STRING_SIZE> name, uint32_t run_period_ms);
     virtual void init();
     virtual float getInputVoltage() const;
@@ -44,13 +53,11 @@ public:
     //    virtual void start();
 
 private:
-    void setrating(float rating, uint8_t channel);
-    void setcapacity(float heater_capacity,
-                     float radiator_capacity,
-                     uint8_t channel);
-    void setconductance(float heater_conductance,
-                        float radiator_conductance,
-                        uint8_t channel);
+    command_error_code_t setAmbient(ICommand *p_command);
+    command_error_code_t setRating(ICommand *p_command);
+    command_error_code_t setCapacity(ICommand *p_command);
+    command_error_code_t setConductance(ICommand *p_command);
+    command_error_code_t setIncubator(ICommand *p_command);
 
     bool mb_power_enable;
     /* Modelling parameters for heater and incubator heat transfer.

--- a/Hardware/CRealHardwareMap.cpp
+++ b/Hardware/CRealHardwareMap.cpp
@@ -61,6 +61,12 @@ CRealHardwareMap::CRealHardwareMap() : m_adc(&hadc1)
     // TODO Auto-generated constructor stub
 }
 
+/**
+ * @brief Initialise hardware peripherals.
+ * @note This method must be called as it sets up all hardware that cannot be
+ * setup at construction time. Example: timers and ADC.
+ *
+ */
 void CRealHardwareMap::init()
 {
     /* all hardware initialisation of peripherals goes here. */
@@ -76,20 +82,41 @@ void CRealHardwareMap::init()
     m_power_enable.init(BREATHING_GPIO_Port, BREATHING_Pin);
 }
 
+/**
+ * @brief Get instantaneous measure of input voltage.
+ *
+ * @return Input power supply voltage in [Volt].
+ */
 float CRealHardwareMap::getInputVoltage() const
 {
     return m_adc[INPUT_VOLTAGE_CHANNEL] * INPUT_VOLTAGE_SCALE;
 }
 
+/**
+ * @brief Get instantaneous measure of total consumed current.
+ *
+ * @return Instant total current in [Amp].
+ */
 float CRealHardwareMap::getTotalCurrent() const
 {
     return m_adc[TOTAL_CURRENT_CHANNEL] * TOTAL_CURRENT_SCALE;
 }
 
+/**
+ * @brief Get instantaneous measure of current consumed by control peripherals.
+ *
+ * @return Instant control current in [Amp].
+ */
 float CRealHardwareMap::getControlCurrent() const
 {
     return m_adc[CONTROL_CURRENT_CHANNEL] * CONTROL_CURRENT_SCALE;
 }
+
+/**
+ * @brief Get ambient temperature from on-board sensor.
+ *
+ * @return Instant temperature from sensor mounted on the PCB.
+ */
 float CRealHardwareMap::getAmbientTemp() const
 {
     float temperature = m_adc[AMBIENT_TEMP_CHANNEL];
@@ -98,6 +125,12 @@ float CRealHardwareMap::getAmbientTemp() const
     return temperature;
 }
 
+/**
+ * @brief Get temperature for off-board thermistor sensor.
+ *
+ * @param channel Number of the channel to query.
+ * @return Temperature for requested channel in [degC].
+ */
 float CRealHardwareMap::getChannelTemp(uint8_t channel) const
 {
     float temperature = m_adc[channel];

--- a/Hardware/IHardwareMap.h
+++ b/Hardware/IHardwareMap.h
@@ -30,21 +30,92 @@ public:
      * underlying peripherals must be done via this interface class.
      * If access is required, then the procedure is to create a virtual method
      * here, then add corresponding implementations in all child classes.
+     * @note Keep in mind that specific details are most likely implementation
+     * dependent. Example: telemetry like voltage and current values might be
+     * instantaneous or digitally filtered.
      */
     /* ADC access */
+    /**
+     * @brief Get input voltage.
+     *
+     * @return Input voltage in [V].
+     */
     virtual float getInputVoltage() const = 0;
+    /**
+     * @brief Get total consumed current. This is essentially control current +
+     * whatever is being consumed by on-board logic.
+     *
+     * @return Total current in [Amp]
+     */
     virtual float getTotalCurrent() const = 0;
+    /**
+     * @brief Get control current. This is current used to power
+     * external power control peripherals.
+     *
+     * @return Control current in [Amp]
+     */
     virtual float getControlCurrent() const = 0;
+    /**
+     * @brief Get ambient temperature.
+     *
+     * @return Temperature in the immediate vicinity of the PCB in [degC]
+     */
     virtual float getAmbientTemp() const = 0;
+    /**
+     * @brief Get temperature of specific thermistor channel.
+     *
+     * @param channel Number of the channel requested.
+     * @return Temperature of the thermistor in [degC]
+     */
     virtual float getChannelTemp(uint8_t channel) const = 0;
     /* PWM control */
+    /**
+     * @brief Set power output of a specific hardware PWM control.
+     *
+     * @param power Value of power output in percent.
+     * @param channel Number of the control channel to set.
+     * @return Value of power output as set by the command in [%]. Might be
+     * range limited.
+     */
     virtual float setHardPwmOutput(float power, uint8_t channel) = 0;
+    /**
+     * @brief Get power output for a control output
+     *
+     * @param channel Number of the control channel to set.
+     * @return Value of power output as set by the command in [%].
+     */
     virtual float getHardPwmOutput(uint8_t channel) = 0;
 #ifdef SOFT_PWM_OUTPUTS
+    /**
+     * @brief Set power output of a specific software PWM control.
+     * @note Software PWM are significantly slower than hardware PWM, so only
+     * suitable for slow control.
+     * @param power Value of power output in percent.
+     * @param channel Number of the control channel to set.
+     * @return Value of power output as set by the command in [%]. Might be
+     * range limited.
+     */
     virtual float setSoftPwmOutput(float power, uint8_t channel) = 0;
+    /**
+     * @brief Get power output for a control output
+     *
+     * @param channel Number of the control channel to set.
+     * @return Value of power output as set by the command in [%].
+     */
     virtual float getSoftPwmOutput(uint8_t channel) = 0;
 #endif
+    /**
+     * @brief Set state of the breathing light. This light is meant to show code
+     * execution state.
+     * @note The actual brightness might or might not be perception corrected.
+     * @param duty_cycle Value in [%] to set brightness of LED.
+     */
     virtual void setBreathingLight(float duty_cycle) = 0;
+    /**
+     * @brief Enable/disable control power to control outputs
+     *
+     * @param b_enable Set to true to enable, false to disable.
+     */
     virtual void enableControlPower(bool b_enable) = 0;
 };
 


### PR DESCRIPTION
Refactor `CMockHardwareMap::newCommand()` for clarity.