### PR TITLE
feature: move MAX_STRING_SIZE definition to etl_profile.h

### DIFF
--- a/Controllers/CDebugController.h
+++ b/Controllers/CDebugController.h
@@ -17,8 +17,6 @@
 #include "CGpioWrapper.h"
 #include "main.h"
 
-#define MAX_STRING_SIZE 60
-
 class CDebugController : public CController
 {
 public:

--- a/Lib/Inc/CController.h
+++ b/Lib/Inc/CController.h
@@ -18,8 +18,6 @@
 #include "IComChannel.h"
 #include "ICommand.h"
 
-#define MAX_STRING_SIZE 60
-
 // comment out if you don't want to collect runtime statistics
 #define COLLECT_STATS
 

--- a/Lib/Inc/IComChannel.h
+++ b/Lib/Inc/IComChannel.h
@@ -15,8 +15,6 @@
 
 #include "../etl/string.h"
 
-#define MAX_STRING_SIZE 60
-
 class IComChannel
 {
 public:

--- a/Lib/Inc/etl_profile.h
+++ b/Lib/Inc/etl_profile.h
@@ -10,4 +10,6 @@
 
 #define ETL_COMPILER_ARM
 
+#define MAX_STRING_SIZE 60
+
 #endif /* ETL_PROFILE_H_ */


### PR DESCRIPTION
There were multiple defines for MAX_STRING_SIZE. Since this is only used with the ETL, I thought it made sense to add this define to etl_profile.h. 