### PR TITLE
feature: add option for a single string argument in parser

### DIFF
--- a/Lib/Inc/CJsonParser.h
+++ b/Lib/Inc/CJsonParser.h
@@ -26,6 +26,7 @@ public:
     bool parse(const etl::string<MAX_STRING_SIZE> &string);
     const etl::string<MAX_STRING_SIZE> *getName() const;
     unsigned int getArgumentCount() const;
+    const etl::string<MAX_STRING_SIZE> *getStringArgument() const;
     float operator[](unsigned int index);
 
     typedef enum TOKEN_TYPE_T
@@ -72,6 +73,7 @@ private:
     uint8_t m_argument_counter = 0;
     etl::string<MAX_STRING_SIZE> m_command_name;
     float m_arguments[MAX_ARGUMENT_COUNT];
+    etl::string<MAX_STRING_SIZE> m_string_argument;
 
     token_t m_current_token;
 

--- a/Lib/Inc/ICommand.h
+++ b/Lib/Inc/ICommand.h
@@ -50,6 +50,13 @@ public:
     virtual unsigned int getArgumentCount() const = 0;
 
     /**
+     * @brief Get string argument.
+     *
+     * @return String argument if available, empty string if not.
+     */
+    virtual const etl::string<MAX_STRING_SIZE> *getStringArgument() const = 0;
+
+    /**
      * @brief Access parsed arguments by index of their position in the command
      * string.
      *

--- a/Lib/Src/CJsonParser.cpp
+++ b/Lib/Src/CJsonParser.cpp
@@ -29,6 +29,7 @@ bool CJsonParser::parse(const etl::string<MAX_STRING_SIZE> &string)
     // Reset command variables
     m_argument_counter = 0;
     m_command_name = "";
+    m_string_argument = "";
 
     stringToTokens(string);
     return parseObject();
@@ -286,6 +287,16 @@ float CJsonParser::operator[](unsigned int index)
 }
 
 /**
+ * @brief Retrieve string stored in m_string_argument
+ * @note If no string was recognised during parsing, this returns an empty
+ * string
+ */
+const etl::string<MAX_STRING_SIZE> *CJsonParser::getStringArgument() const
+{
+    return &m_string_argument;
+}
+
+/**
  * @note The following methods parse non-terminal symbols. To understand better
  * the logic behind these methods please Google Recursive Descent Parser or
  * visit: http://www.cs.binghamton.edu/~zdu/parsdemo/recintro.html
@@ -373,6 +384,11 @@ bool CJsonParser::parseValue()
             m_arguments[m_argument_counter++] = number;
             b_success = true;
         }
+    }
+    else if (m_tokens[m_token_index].type == STRING)
+    {
+        m_string_argument = m_tokens[m_token_index].text;
+        b_success = true;
     }
     return b_success;
 }


### PR DESCRIPTION
I added the option to parse a single string as argument (no arrays). I needed this for the Dispatcher and I think it could be useful for other things.