### PR TITLE
fix: add ADC trigger in temperature controller

### DIFF
--- a/Controllers/CTemperatureController.cpp
+++ b/Controllers/CTemperatureController.cpp
@@ -62,6 +62,7 @@ void CTemperatureController::run()
         }
         mp_hw->setHardPwmOutput(power, i);
     }
+    mp_hw->triggerADC();
 }
 
 bool CTemperatureController::newCommand(ICommand *p_command,

--- a/Hardware/CMockHardwareMap.h
+++ b/Hardware/CMockHardwareMap.h
@@ -40,6 +40,7 @@ public:
     virtual void run();
     virtual bool newCommand(ICommand *p_command, IComChannel *p_comchannel);
     virtual void reset();
+    virtual void triggerADC(){};
     //    virtual void stop();
     //    virtual void start();
 

--- a/Hardware/CRealHardwareMap.cpp
+++ b/Hardware/CRealHardwareMap.cpp
@@ -170,3 +170,8 @@ void CRealHardwareMap::enableControlPower(bool b_enable)
 {
     m_power_enable.set(b_enable);
 }
+
+void CRealHardwareMap::triggerADC()
+{
+    m_adc.trigger();
+}

--- a/Hardware/CRealHardwareMap.h
+++ b/Hardware/CRealHardwareMap.h
@@ -40,6 +40,7 @@ public:
 #endif
     virtual void setBreathingLight(float duty_cycle);
     virtual void enableControlPower(bool b_enable);
+    virtual void triggerADC();
 
 private:
     typedef struct TIMER_INIT_MAP_T

--- a/Hardware/IHardwareMap.h
+++ b/Hardware/IHardwareMap.h
@@ -117,6 +117,11 @@ public:
      * @param b_enable Set to true to enable, false to disable.
      */
     virtual void enableControlPower(bool b_enable) = 0;
+
+    /**
+     * @brief Trigger ADC readings to fill DMA buffer
+     */
+    virtual void triggerADC() = 0;
 };
 
 #endif /* IHARDWAREMAP_H_ */


### PR DESCRIPTION
I was testing the ADC channels and realised the data was not being updated because the ADC trigger was not called in the infinite loop. This is a quick fix so we can test data. I'll try writing something better. 
When I wrote the code for the ADC class I didn't know much about DMA and circular buffers, that's why I chose this option to trigger the readings "manually". I **think** I could change this to continuously fill the DMA buffer without needing a trigger. 