### PR TITLE
Use ghcr image

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -32,15 +32,15 @@ jobs:
         run: |
           chmod +x /opt/st/stm32cubeide_1.9.0/headless-build.sh
           cd /opt/st/stm32cubeide_1.9.0
-          ./headless-build.sh -data /workspace -import /__w/Multichannel-Temperature-Control/Multichannel-Temperature-Control -cleanBuild 'Multichannel temperature sensor' -markerType cdt || { echo "Build Failed"; exit 1; }
+          ./headless-build.sh -data /workspace -import /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }} -cleanBuild 'Multichannel temperature sensor' -markerType cdt || { echo "Build Failed"; exit 1; }
       - uses: actions/upload-artifact@v3
         with:
           name: debug_build
-          path: /__w/Multichannel-Temperature-Control/Multichannel-Temperature-Control/Debug/Multichannel\ temperature\ sensor.bin
+          path: /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}/Debug/Multichannel\ temperature\ sensor.bin
       - uses: actions/upload-artifact@v3
         with:
           name: release_build
-          path: /__w/Multichannel-Temperature-Control/Multichannel-Temperature-Control/Release/Multichannel\ temperature\ sensor.bin
+          path: /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}/Release/Multichannel\ temperature\ sensor.bin
   
   flash_debug:
     runs-on: self-hosted

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -21,7 +21,11 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    container: niuslar/stm32-cubeide-headless:latest
+    container: 
+      image: ghcr.io/niuslar/stm32-cubeide-headless:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
     steps:
       - uses: actions/checkout@v3
       - name: Build App

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -21,11 +21,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    container: 
-      image: ghcr.io/niuslar/stm32-cubeide-headless:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.github_token }}
+    container: ghcr.io/niuslar/stm32-cubeide-headless:latest
     steps:
       - uses: actions/checkout@v3
       - name: Build App


### PR DESCRIPTION
Hi, I updated the workflow so that it now uses the ghcr image when building the binary.

On an unrelated note, I noticed that the deploy steps, flash_debug and flash_release, are both deploying on hardware (the same hardware?), potentially at the same time. 
Steps in workflows are running in different processes, which could run concurrently on a Raspberry, so it shouldn't work or, at best, it might "work" with unexpected crashes. 
What am I missing?